### PR TITLE
Add optional db input param

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ pump(socket, feed.replicate(), socket)
 
 ## API
 
-#### `var ar = archiver(folder|db)`
+#### `var ar = archiver(folder|db, [storage])`
 
-Create a new archiver. Can pass folder or db, where folder is the path to where data will be stored, or db is a level-up compatible instance (eg memdb).
+Create a new archiver. Can pass folder or db, where folder is the path to where data will be stored, or db is a level-up compatible instance (eg memdb). Can also pass a storage option, the [random-access-file](https://github.com/mafintosh/random-access-file) module or [random-access-memory](https://github.com/mafintosh/random-access-memory).
 
 #### `ar.changes(callback)`
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ pump(socket, feed.replicate(), socket)
 
 ## API
 
-#### `var ar = archiver(folder)`
+#### `var ar = archiver(folder|db)`
 
-Create a new archiver. Folder is where on disk the data will be stored.
+Create a new archiver. Can pass folder or db, where folder is the path to where data will be stored, or db is a level-up compatible instance (eg memdb).
 
 #### `ar.changes(callback)`
 

--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@ var thunky = require('thunky')
 
 module.exports = create
 
-function create (dir) {
-  if (!dir) dir = '.'
+function create (dbOrDr) {
+  if (!dbOrDr) dbOrDr = '.'
 
-  var db = level(path.join(dir, 'db'))
+  var db = typeof dbOrDr === 'string' ? level(path.join(dbOrDr, 'db')) : dbOrDr
   var misc = subleveldown(db, 'misc', {valueEncoding: 'binary'})
   var keys = subleveldown(db, 'added-keys', {valueEncoding: 'binary'})
   var core = hypercore(db)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var hypercore = require('hypercore')
 var level = require('level')
 var path = require('path')
-var storage = require('random-access-file')
+var raf = require('random-access-file')
 var encoding = require('hyperdrive-encoding')
 var subleveldown = require('subleveldown')
 var collect = require('stream-collector')
@@ -12,9 +12,10 @@ var thunky = require('thunky')
 
 module.exports = create
 
-function create (dbOrDr) {
+function create (dbOrDr, storageOpt) {
   if (!dbOrDr) dbOrDr = '.'
 
+  var storage = storageOpt || raf
   var db = typeof dbOrDr === 'string' ? level(path.join(dbOrDr, 'db')) : dbOrDr
   var misc = subleveldown(db, 'misc', {valueEncoding: 'binary'})
   var keys = subleveldown(db, 'added-keys', {valueEncoding: 'binary'})


### PR DESCRIPTION
This PR makes it possible to pass a DB instance instead of a file-path into the factory, which is good for passing in memdb instances during testing