### PR TITLE
fix: clear entry tracking opened feed when closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ function create (opts) {
     function close () {
       if (--old.cnt) return
       old.feed = null
+      opened[hex] = null
       feed.close()
     }
   }


### PR DESCRIPTION
Another part of the fix that was missed in https://github.com/mafintosh/hypercore-archiver/pull/8#issuecomment-269551558

cc @mafintosh 