### PR TITLE
fix: dont open a feed for a replication stream that has been destroyed

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,6 +175,7 @@ function create (opts) {
   }
 
   function open (key, maybeContent, stream) {
+    if (stream.destroyed) return
     key = datKeyAs.str(key)
 
     var hex = that.discoveryKey(new Buffer(key, 'hex')).toString('hex')


### PR DESCRIPTION
Related to https://github.com/joehand/hypercloud/issues/16

This one was a tricky one!

There was a case where a feed's storage was being closed prematurely. This led to writes failing. Replication would then stall (see https://github.com/mafintosh/hypercore/issues/54) but did appear to complete successfully if the connection was re-established.

Why was the FD closing prematurely? It's possible that the protocol handshake will uncover an extraneous connection, which needs to be destroyed. Sometimes one of those destroyed connections would be the first to enter the open() logic in this repo. The cleanup() check would see that the stream is destroyed, and that there are no other active streams, and so would call feed.close(). Afterward, other non-destroyed streams would continue processing, and try to write into the feed causing the failure.

It looks like there's no harm in just ignoring open() for any stream that's already destroyed, so that's what this PR does.