### PR TITLE
fixes issue #30. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ var swarm = require('hypercore-archiver/swarm')
 swarm(archiver)
 ```
 
+The swarm listens on port 3282, both tcp and udp. If you require a different port, pass in the port as an option
+
+```js
+var swarm = require('hypercore-archiver/swarm')
+swarm(archiver, {port: 60234}
+```
+
 ## License
 
 MIT

--- a/swarm.js
+++ b/swarm.js
@@ -5,6 +5,7 @@ var defaults = require('datland-swarm-defaults')
 module.exports = swarm
 
 function swarm (archiver, opts) {
+  var port = opts.port || 3282
   var swarmOpts = xtend({
     hash: false,
     stream: function (opts) {
@@ -26,7 +27,7 @@ function swarm (archiver, opts) {
     sw.leave(feed.discoveryKey)
   })
 
-  sw.listen(3282)
+  sw.listen(port)
   sw.once('error', function () {
     sw.listen()
   })


### PR DESCRIPTION
Allow passing in a port to the swarm, and document it in the readme.

note, I excluded the port from the swarmOpts = xtend because I did not want to pass in an unused property into the constructor. 

